### PR TITLE
Remove ZAP reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This repository contains web applications protected by OWASP projects that are r
 Researchers can download and run locally these applications in order to test their security.
 Explanation regarding each bounty scope please visit each project page at BugCrowd Bounty Source pages here:
 ####Running at the moment:
-*OWASP ZAP : https://bugcrowd.com/owaspzap
-
 *OWASP Java HTML Sanitizer: https://bugcrowd.com/owaspjavasanitizer
 
 *OWASPCRSFGuard:https://bugcrowd.com/owaspcrsfguard


### PR DESCRIPTION
ZAP was removed from the OWASP BB platform this winter.